### PR TITLE
updating aws ecr get-login to get-login-password

### DIFF
--- a/scripts/env_prep.sh
+++ b/scripts/env_prep.sh
@@ -139,7 +139,10 @@ setup_ecr ${proc_repo_name}
 
 
 # Get docker credentials for the repositories
-aws ecr get-login --no-include-email --profile ${PROFILE} | bash
+# outdated command from v1
+# aws ecr get-login --no-include-email --profile ${PROFILE} | bash
+# This command is supported using the latest version of AWS CLI version 2 or in v1.17.10 or later of AWS CLI version 1
+aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
 
 # Build and push docker images
 build_docker ${start_docker_path} ${start_repo_name} ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com

--- a/scripts/env_prep.sh
+++ b/scripts/env_prep.sh
@@ -142,7 +142,7 @@ setup_ecr ${proc_repo_name}
 # outdated command from v1
 # aws ecr get-login --no-include-email --profile ${PROFILE} | bash
 # This command is supported using the latest version of AWS CLI version 2 or in v1.17.10 or later of AWS CLI version 1
-aws ecr get-login-password --region $REGION --profile ${PROFILE} | docker login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+aws ecr get-login-password --region ${REGION} --profile ${PROFILE} | docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com
 
 # Build and push docker images
 build_docker ${start_docker_path} ${start_repo_name} ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com

--- a/scripts/env_prep.sh
+++ b/scripts/env_prep.sh
@@ -142,7 +142,7 @@ setup_ecr ${proc_repo_name}
 # outdated command from v1
 # aws ecr get-login --no-include-email --profile ${PROFILE} | bash
 # This command is supported using the latest version of AWS CLI version 2 or in v1.17.10 or later of AWS CLI version 1
-aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+aws ecr get-login-password --region $REGION --profile ${PROFILE} | docker login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
 
 # Build and push docker images
 build_docker ${start_docker_path} ${start_repo_name} ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com


### PR DESCRIPTION
Updating to `aws ecr get-login-password` command:

This command is supported using the latest version of AWS CLI version 2 or in v1.17.10 or later of AWS CLI version 1. 
https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecr/get-login-password.html

```
AWS CLI version 2, the latest major version of AWS CLI, is now stable and recommended for general use. This command is deprecated in AWS CLI version 2, use get-login-password instead
```
https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html